### PR TITLE
Use mktemp to avoid collision

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,15 +3,5 @@ description: setup aws-cli v2
 runs:
   using: composite
   steps:
-    # https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html
-    - run: curl -sf "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-      working-directory: /tmp
-      shell: bash
-    - run: unzip -q awscliv2.zip
-      working-directory: /tmp
-      shell: bash
-    - run: sudo ./aws/install
-      working-directory: /tmp
-      shell: bash
-    - run: aws --version
+    - run: ${{ github.action_path }}/run.sh
       shell: bash

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -o pipefail
+set -eux
+
+cd "$(mktemp -d)"
+
+# https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html
+curl -sf "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip -q awscliv2.zip
+sudo ./aws/install
+aws --version


### PR DESCRIPTION
Sometimes the following error occurs:

```console
replace aws/README.md? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
(EOF or read error, treating as "[N]one" ...)
```

This will fix the error by using an ephemeral working directory.
