### PR TITLE
Fix error when aws-cli already exists

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,16 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  when-aws-cli-does-not-exist:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       # delete preexisting one
       - run: sudo rm -fr /usr/local/aws-cli
+      - uses: ./
+
+  when-aws-cli-already-exists:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
       - uses: ./

--- a/run.sh
+++ b/run.sh
@@ -7,5 +7,5 @@ cd "$(mktemp -d)"
 # https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html
 curl -sf "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip -q awscliv2.zip
-sudo ./aws/install
+sudo ./aws/install --update
 aws --version


### PR DESCRIPTION
Eventually I got the following error on a self-hosted runner:

```
+ sudo ./aws/install
Found preexisting AWS CLI installation: /usr/local/aws-cli/v2/current. Please rerun install script with --update flag.
Error: Process completed with exit code 1.
```

like: https://github.com/quipper/setup-aws-cli-action/runs/2637067239?check_suite_focus=true

This PR will fix that.