### PR TITLE
Invoke run.sh via bash

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -3,5 +3,5 @@ description: setup aws-cli v2
 runs:
   using: composite
   steps:
-    - run: ${{ github.action_path }}/run.sh
+    - run: exec bash ${{ github.action_path }}/run.sh
       shell: bash


### PR DESCRIPTION
## Problem to solve
If `run.sh` does not have an executable permission, such as mounted via docker, this action does not work properly.
It would be nice to invoke it via bash.
