### PR TITLE
Skip installation if aws command is available

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -7,6 +7,9 @@ runs:
     - shell: bash
       run: |
         set -eux
+        if aws --version; then
+          exit
+        fi
         cd "$(mktemp -d)"
         curl -sf "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o awscliv2.zip
         unzip -q awscliv2.zip


### PR DESCRIPTION
To reduce a time to download and install aws-cli, skip it if aws command is available.
